### PR TITLE
Add /ahtogglerecycle command & update Spanish lang 

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ A powerful WoW addon designed to streamline the attunement process by automatica
 
 ### 📋 Requirements
 - **WoW Version:** 3.3.5a (WotLK)
-- **Optional:** [SynastriaCoreLib](https://github.com/imevul/SynastriaCoreLib/releases) for enhanced functionality
+- **Synastria.org**
 
 ## 📖 Usage Guide
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ A powerful WoW addon designed to streamline the attunement process by automatica
 
 ### 📋 Requirements
 - **WoW Version:** 3.3.5a (WotLK)
-- Synastria.org
+- **Optional:** [SynastriaCoreLib](https://github.com/imevul/SynastriaCoreLib/releases) for enhanced functionality
 
 ## 📖 Usage Guide
 
@@ -99,6 +99,7 @@ A powerful WoW addon designed to streamline the attunement process by automatica
 | `/ahsetall` | Add all currently equipped items to set |
 | `/ahignore <itemlink>` | Toggle item ignore status |
 | `/ahignorelist` | List all ignored items |
+| `/ahtogglerecycle` | Toggle between selling or keeping attuned white and grey items |
 
 ### 🚫 Slot Blacklisting
 | Command | Description |

--- a/src/AttuneHelper/README.md
+++ b/src/AttuneHelper/README.md
@@ -99,6 +99,7 @@ A powerful WoW addon designed to streamline the attunement process by automatica
 | `/ahsetall` | Add all currently equipped items to set |
 | `/ahignore <itemlink>` | Toggle item ignore status |
 | `/ahignorelist` | List all ignored items |
+| `/ahtogglerecycle` | Toggle between selling or keeping attuned white and grey items |
 
 ### 🚫 Slot Blacklisting
 | Command | Description |

--- a/src/AttuneHelper/core/locale.lua
+++ b/src/AttuneHelper/core/locale.lua
@@ -39,25 +39,25 @@ local enUS = {
     ["Items must be: Mythic, 100% attuned, soulbound, not in sets/ignore lists."] = "Items must be: Mythic, 100% attuned, soulbound, not in sets/ignore lists.",
 }
 
-local esES = { -- AI GENERATED NO VERIFICATION
-    ["Equip Attunables"]      = "Equipar sintonizables",
+local esES = { -- Reviewed by LiquidAP and Moonlight
+    ["Equip Attunables"]      = "Equipar sincronizables",
     ["Prepare Disenchant"]    = "Preparar desencantar",
-    ["Vendor Attuned"]        = "Vender sintonizado",
-    ["Vendor Attuned Items"]  = "Vender objetos sintonizados",
+    ["Vendor Attuned"]        = "Vender sincronizados",
+    ["Vendor Attuned Items"]  = "Vender objetos sincronizados",
     ["System Default"]        = "Predeterminado del sistema",
     ["English (US)"]          = "Inglés (EE.UU.)",
     ["Español"]               = "Español",
     ["Deutsch"]               = "Alemán",
     ["Select Language:"]      = "Seleccionar idioma:",
-    ["Moves fully attuned mythic items to bag %d."] = "Mueve los objetos míticos totalmente sintonizados a la bolsa %d.",
+    ["Moves fully attuned mythic items to bag %d."] = "Mueve los objetos míticos totalmente sincronizados a la bolsa %d.",
     ["Clears target bag first, then fills with disenchant-ready items."] = "Vacía primero la bolsa objetivo y luego la llena con objetos listos para desencantar.",
-    ["Attunable Items: %d"]    = "Objetos sintonizables: %d",
-    ["Qualifying Attunables (%d):"] = "Sintonizables cualificados (%d):",
-    ["No qualifying attunables in bags."] = "No hay sintonizables cualificados en las bolsas.",
+    ["Attunable Items: %d"]    = "Objetos sincronizables: %d",
+    ["Qualifying Attunables (%d):"] = "Sincronizables elegibles (%d):",
+    ["No qualifying attunables in bags."] = "No hay sincronizables elegibles en las bolsas.",
     ["Items to be sold (%d):"] = "Objetos a vender (%d):",
     ["No items will be sold based on current settings."] = "No se venderán objetos según la configuración actual.",
     ["Open merchant window to sell these items."] = "Abre la ventana del vendedor para vender estos objetos.",
-    ["Items must be: Mythic, 100% attuned, soulbound, not in sets/ignore lists."] = "Los objetos deben ser: míticos, 100% sintonizados, ligados, no en conjuntos/listas de ignorados.",
+    ["Items must be: Mythic, 100% attuned, soulbound, not in sets/ignore lists."] = "Los objetos deben ser míticos y estar: 100% sincronizados, ligados, fuera de conjuntos/listas de ignorados.",
 }
 
 local deDE = { -- AI GENERATED NO VERIFICATION

--- a/src/AttuneHelper/core/util.lua
+++ b/src/AttuneHelper/core/util.lua
@@ -156,6 +156,7 @@ function AH.InitializeDefaultSettings()
     if AttuneHelperDB["MiniFramePosition"] == nil then AttuneHelperDB["MiniFramePosition"] = { "CENTER", UIParent, "CENTER", 0, 0 } end
     if AttuneHelperDB["Disable Two-Handers"] == nil then AttuneHelperDB["Disable Two-Handers"] = 0 end
     if AttuneHelperDB["Language"] == nil then AttuneHelperDB["Language"] = "default" end
+	if AttuneHelperDB["Vendor Attuned Grey And White Items"] == nil then AttuneHelperDB["Vendor Attuned Grey And White Items"] = 0 end
 
     -- Handle legacy setting migration
     if AttuneHelperDB["EquipUntouchedVariants"] ~= nil and AttuneHelperDB["EquipNewAffixesOnly"] == nil then
@@ -190,6 +191,7 @@ function AH.InitializeDefaultSettings()
         ["Limit Selling to 12 Items?"] = 0, 
         ["Disable Auto-Equip Mythic BoE"] = 1, 
         ["Equip BoE Bountied Items"] = 0,
+		["Vendor Attuned Grey And White Items"] = 0,
         ["Mini Mode"] = 0, 
         ["EquipNewAffixesOnly"] = 0, 
         ["Prioritize Low iLvl for Auto-Equip"] = 1,

--- a/src/AttuneHelper/gameplay/slash_cmds.lua
+++ b/src/AttuneHelper/gameplay/slash_cmds.lua
@@ -308,6 +308,12 @@ SlashCmdList["AHBLL"] = function()
     end
 end
 
+SLASH_AHTOGGLERECYCLE1 = "/ahtogglerecycle"
+SlashCmdList["AHTOGGLERECYCLE"] = function()
+    AttuneHelperDB["Vendor Attuned Grey And White Items"] = 1 - (AttuneHelperDB["Vendor Attuned Grey And White Items"] or 0)
+    print("|cffffd200[AH]|r Vendor Attuned Grey And White Items: " .. (AttuneHelperDB["Vendor Attuned Grey And White Items"] == 1 and "|cff00ff00Enabled|r." or "|cffff0000Disabled|r."))
+end
+
 function AH.SlashCommand(msg)
     if not msg then return end
     

--- a/src/AttuneHelper/gameplay/vendor_logic.lua
+++ b/src/AttuneHelper/gameplay/vendor_logic.lua
@@ -143,6 +143,12 @@ function AH.GetQualifyingVendorItems()
                             skipReason = "This variant only " .. thisVariantProgress .. "% attuned"
                         end
                     end
+					
+					-- Check poor or normal quality
+					if not skip and not (AttuneHelperDB["Vendor Attuned Grey And White Items"] == 1) then
+                        skip = true
+                        skipReason = "Item is attunable by other accounts."
+                    end
 
                     -- Final qualification checks
                     if not skip then


### PR DESCRIPTION
Added /ahtogglerecycle command, which toggles whether attuned grey and white items are vendored when pressing "Vendor Attuned Items". 
The default setting makes you keep the items.

Reviewed the Spanish translation and chose "sincronizar" as the closest verb to "attune" in the Synastria context.